### PR TITLE
Udate readme. Add link to Hapi implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 this repository is a node.js/express template application for use with the 
 Heroku <a href="http://github.com/heroku/kensa">kensa</a> gem
 
+You can find a node.js/hapi template implementation here: <a href="https://github.com/KevinGrandon/kensa-create-node-hapi">kensa-create-node-hapi</a>
+
 dependencies:
 
     > gem install kensa


### PR DESCRIPTION
Hapi is becoming a pretty popular node framework and I could not find a template for the kensa Heroku addon, so I made one. It's not perfect yet, but the kensa tests are passing with it, and it may be worth adding a link to it so other developers can find it.
